### PR TITLE
panic() if we ever get disconnected from Firestore for watching transactions or entities

### DIFF
--- a/server/transaction_watcher.go
+++ b/server/transaction_watcher.go
@@ -364,8 +364,7 @@ func createTransactionWatcher(ctx context.Context, client *firestore.Client, sch
 			for true {
 				snapshot, err := snapshots.Next()
 				if err != nil {
-					log.Printf("error during entity watch: %v", err)
-					return
+					panic(fmt.Sprintf("unrecoverable error during entity watch: %v", err))
 				}
 
 				for _, change := range snapshot.Changes {
@@ -413,8 +412,7 @@ func createTransactionWatcher(ctx context.Context, client *firestore.Client, sch
 		for true {
 			transactionSnapshot, err := transactions.Next()
 			if err != nil {
-				log.Printf("error during transaction watch: %v", err)
-				return
+				panic(fmt.Sprintf("unrecoverable error during transaction watch: %v", err))
 			}
 
 			watcher.transactionsLock.Lock()


### PR DESCRIPTION
We can't safely recover from these scenarios at the moment, because even if we reconnect, there's a chance the incoming messages don't represent a reconstructed history. And because at this point, configstore isn't running in a "reconstruct initial state" mode, it's possible for it to get stalled out waiting for transaction components that never arrive.

It's better to panic() here, let configstore restart and do the proper initial state reconstruction before propagating the whole new state down to clients.